### PR TITLE
build(release): bump version to 4.2.2_04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ LABEL name="oxTrust" \
     maintainer="Gluu Inc. <support@gluu.org>" \
     vendor="Gluu Federation" \
     version="4.2.2" \
-    release="03" \
+    release="04" \
     summary="Gluu oxTrust" \
     description="Gluu Server UI for managing authentication, authorization and users"
 

--- a/__version__.py
+++ b/__version__.py
@@ -3,5 +3,5 @@
  https://www.apache.org/licenses/LICENSE-2.0
  This is only used by Github actions: release.yaml workflow.
 """
-__version__ = "4.2.2_03"
-__previous_version__ = "4.2.2_02"
+__version__ = "4.2.2_04"
+__previous_version__ = "4.2.2_03"


### PR DESCRIPTION
Overview:

- remove deprecated RClone package
- change source of Jython installer
- upgrade to oxtrust-server 4.2.2.sp1